### PR TITLE
게시글 조회 기능 수정(3)

### DIFF
--- a/app/src/main/java/com/goodee/cando_app/model/DiaryRepository.kt
+++ b/app/src/main/java/com/goodee/cando_app/model/DiaryRepository.kt
@@ -24,15 +24,16 @@ class DiaryRepository(val application: Application) {
         get() = _diaryLiveData
 
     // 게시글 조회(게시글 클릭 시 1개의 게시글을 읽음)
-    suspend fun getDiary(dno: String): DiaryDto? {
+    suspend fun refreshDiaryLiveData(dno: String): Boolean {
         Log.d(TAG,"AppRepository - getDiary() called")
         val qResult = FirebaseFirestore.getInstance().collection("diary").whereEqualTo("dno", dno).get().await()
         // if : There is no document has a same diary and dno.
         if (qResult.isEmpty) {
-            return null
+            return false
         }
 
-        return qResult.first().toObject(DiaryDto::class.java)
+        _diaryLiveData.postValue(qResult.first().toObject(DiaryDto::class.java))
+        return true
     }
 
     // 게시글 목록 가져오기(로그인시 바로 보이는 게시글들)

--- a/app/src/main/java/com/goodee/cando_app/viewmodel/DiaryViewModel.kt
+++ b/app/src/main/java/com/goodee/cando_app/viewmodel/DiaryViewModel.kt
@@ -9,7 +9,9 @@ import com.goodee.cando_app.dto.DiaryDto
 import com.goodee.cando_app.model.DiaryRepository
 
 class DiaryViewModel(application: Application) : AndroidViewModel(application) {
-    private val TAG: String = "로그"
+    companion object {
+        private const val TAG: String = "로그"
+    }
     private var diaryRepository: DiaryRepository
     private val _diaryListLiveData: MutableLiveData<List<DiaryDto>>
     val diaryListLiveData: LiveData<List<DiaryDto>>
@@ -26,9 +28,10 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     // 게시글 1개 가져오기
-    suspend fun getDiary(dno: String): DiaryDto? {
-        return diaryRepository.getDiary(dno)
+    suspend fun refreshDiaryLiveData(dno: String): Boolean {
+        return diaryRepository.refreshDiaryLiveData(dno)
     }
+
     // 글 작성하기
     fun writeDiary(diaryDto: DiaryDto) {
         diaryRepository.writeDiary(diaryDto)

--- a/app/src/main/java/com/goodee/cando_app/views/diary/DiaryViewFragment.kt
+++ b/app/src/main/java/com/goodee/cando_app/views/diary/DiaryViewFragment.kt
@@ -1,8 +1,10 @@
 package com.goodee.cando_app.views.diary
 
 import android.app.AlertDialog
+import android.content.Context
 import android.os.Bundle
 import android.util.Log
+import android.view.ContextMenu
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -31,44 +33,37 @@ class DiaryViewFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // 번호가 전달이 안됐으면 이전 페이지로 이동
-        when (arguments) {
-            null -> {
-                findNavController().navigateUp()
-            }
-        }
-
-        // 전달이 됐으면 글을 조회
-        dno = arguments?.get("dno").toString()
-        lifecycleScope.launch(Dispatchers.IO) {
-            val diaryDto = diaryViewModel.getDiary(dno)
-            withContext(Dispatchers.Main) {
-                when (diaryDto) {
-                    null -> {
-                        val alertDialog = AlertDialog.Builder(requireContext()).create()
-                        alertDialog.setTitle("오류")
-                        alertDialog.setMessage("이미 삭제 된 글입니다.")
-                        alertDialog.setButton(AlertDialog.BUTTON_NEUTRAL, "확인") { _, _ ->
-                            findNavController().navigateUp()
-                        }
-                    }
-                    else -> {
-                        binding.textviewDiaryviewTitleview.text = diaryDto.title
-                        binding.textviewDiaryviewContentview.text = diaryDto.content
-                        binding.textviewDiaryViewAuthorView.text = diaryDto.author
-                        binding.progressbarDiaryviewLoading.visibility = View.GONE
-                    }
-                }
-            }
-        }
+        Log.d(TAG, "DiaryViewFragment - onCreate() called")
     }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        Log.d(TAG,"DiaryViewFragment - onCreateView() called")
+        Log.d(TAG, "DiaryViewFragment - onCreateView() called")
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_diary_view, container, false)
+        diaryViewModel.diaryLiveData.observe(viewLifecycleOwner) { diaryDto ->
+            binding.textviewDiaryviewTitleview.text = diaryDto.title
+            binding.textviewDiaryviewContentview.text = diaryDto.content
+            binding.textviewDiaryViewAuthorView.text = diaryDto.author
+            binding.progressbarDiaryviewLoading.visibility = View.GONE
+        }
+
+        // 전달이 됐으면 글을 조회
+        dno = arguments?.get("dno").toString()
+        lifecycleScope.launch(Dispatchers.IO) {
+            val isSuccess = diaryViewModel.refreshDiaryLiveData(dno)
+            withContext(Dispatchers.Main) {
+                if (!isSuccess) {
+                    val alertDialog = AlertDialog.Builder(requireContext()).create()
+                    alertDialog.setTitle("오류")
+                    alertDialog.setMessage("이미 삭제 된 글입니다.")
+                    alertDialog.setButton(AlertDialog.BUTTON_NEUTRAL, "확인") { _, _ ->
+                        findNavController().navigateUp()
+                    }
+                }
+            }
+        }
         setEvent()
 
         return binding.root
@@ -76,13 +71,13 @@ class DiaryViewFragment : Fragment() {
 
     private fun setEvent() {
         binding.buttonDiaryviewEditbutton.setOnClickListener {
-            Log.d(TAG,"DiaryViewFragment - editButton is clicked.")
+            Log.d(TAG, "DiaryViewFragment - editButton is clicked.")
             findNavController().navigate(
                 DiaryViewFragmentDirections.actionDiaryViewFragmentToDiaryWriteFragment(dno)
             )
         }
         binding.buttonDiaryviewDeletebutton.setOnClickListener {
-            Log.d(TAG,"DiaryViewFragment - deleteButton is clicked")
+            Log.d(TAG, "DiaryViewFragment - deleteButton is clicked")
             val dialog = DiaryDeleteDialogFragment(dno)
             dialog.show(requireActivity().supportFragmentManager, "쇼")
         }


### PR DESCRIPTION
게시글을 조회하면 ViewModel에 저장하는 방식으로 수정했다.
DiaryViewFragment.kt에서 DiaryWriteFragment.kt로 이동한 후에
다시 뒤로 가기를 통해 DiaryViewFragment.kt화면으로 이동하면 onCreateView부터 라이프사이클이 진행돼서 글이 조회가 안되는 문제가 생겼다.

생각해낸 해결 방법은 3가지
1.onCreate에서 onCreateView로 글을 조회하는 기능을 옮긴다.
2.bundle에 저장한다.
3.뷰모델에 게시글에 정보를 저장한다.

2번 방법은 나중에 게시글에 용량이 커지거나 할 경우 앱의 성능이 저하될 우려가 있어 쓰지 않았다.
1번 방법도 좋지만 파이어스토어 요청 용량 제한도 있고, 매번 데이터를 조회하기보다는 뷰모델에 저장하는 3번이 맘에 들어서 3번을 사용하였다.