### PR TITLE
글 보기 기능 수정(다른 사람이 수정 가능)

### DIFF
--- a/app/src/main/java/com/goodee/cando_app/viewmodel/DiaryViewModel.kt
+++ b/app/src/main/java/com/goodee/cando_app/viewmodel/DiaryViewModel.kt
@@ -49,14 +49,14 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
         diaryRepository.deleteDiary(dno)
     }
 
-    override fun onCleared() {
-        super.onCleared()
-        Log.d(TAG,"DiaryViewModel - onCleared() called")
-    }
-
     // refresh Diary List live data from Firestore.
     suspend fun refreshDiaryList(): Boolean {
         Log.d(TAG,"DiaryViewModel - refreshDiaryList() called")
         return diaryRepository.refreshDiaryList()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        Log.d(TAG,"DiaryViewModel - onCleared() called")
     }
 }

--- a/app/src/main/java/com/goodee/cando_app/views/diary/DiaryViewFragment.kt
+++ b/app/src/main/java/com/goodee/cando_app/views/diary/DiaryViewFragment.kt
@@ -1,7 +1,6 @@
 package com.goodee.cando_app.views.diary
 
 import android.app.AlertDialog
-import android.content.Context
 import android.os.Bundle
 import android.util.Log
 import androidx.fragment.app.Fragment
@@ -15,6 +14,7 @@ import androidx.navigation.fragment.findNavController
 import com.goodee.cando_app.R
 import com.goodee.cando_app.databinding.FragmentDiaryViewBinding
 import com.goodee.cando_app.viewmodel.DiaryViewModel
+import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -44,6 +44,12 @@ class DiaryViewFragment : Fragment() {
             binding.textviewDiaryviewContentview.text = diaryDto.content
             binding.textviewDiaryViewAuthorView.text = diaryDto.author
             binding.progressbarDiaryviewLoading.visibility = View.GONE
+
+            // if : 로그인한 유저의 이메일과 게시자의 이메일이 일치 -> 글 수정, 삭제 버튼을 보여줌.
+            if (FirebaseAuth.getInstance().currentUser?.email == diaryViewModel.diaryLiveData.value?.author) {
+                binding.buttonDiaryviewEditbutton.visibility = View.VISIBLE
+                binding.buttonDiaryviewDeletebutton.visibility = View.VISIBLE
+            }
         }
 
         // 전달이 됐으면 글을 조회
@@ -58,6 +64,7 @@ class DiaryViewFragment : Fragment() {
                     alertDialog.setButton(AlertDialog.BUTTON_NEUTRAL, "확인") { _, _ ->
                         findNavController().navigateUp()
                     }
+                    alertDialog.show()
                 }
             }
         }
@@ -78,5 +85,12 @@ class DiaryViewFragment : Fragment() {
             val dialog = DiaryDeleteDialogFragment(dno)
             dialog.show(requireActivity().supportFragmentManager, "쇼")
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        // When you leave fragment or navigate to next fragment.
+        // It will clear ViewModel.
+        activity?.viewModelStore?.clear()
     }
 }

--- a/app/src/main/res/layout/fragment_diary_view.xml
+++ b/app/src/main/res/layout/fragment_diary_view.xml
@@ -42,16 +42,18 @@
             android:layout_height="wrap_content"
             android:text="@string/diary_view_edit_button"
             android:textSize="14sp"
+            android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@id/button_diaryview_deletebutton"
             app:layout_constraintTop_toBottomOf="@id/textview_diaryview_contentview"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:layout_constraintBottom_toBottomOf="parent" />
         <Button
             android:id="@+id/button_diaryview_deletebutton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/diary_view_delete_button"
             android:textSize="14sp"
+            android:visibility="gone"
             app:layout_constraintStart_toEndOf="@id/button_diaryview_editbutton"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/textview_diaryview_contentview"/>


### PR DESCRIPTION
만약, 다른 사람 글을 보기 전에 자신의 글을 본 경우 뷰모델(DiaryViewModel)의 라이브 데이터(diaryLiveData)가 자신의 글로 초기화 되어 있음.
이 상태에서 다른 사람의 글로 이동하는 경우, 이전의 자신의 글을 조회하고 남은 라이브 데이터를 인식해서 자신의 글로 판단한다.
이로 인해 수정 버튼과 삭제 버튼을 보여주는 버그가 생긴다.

해결 방법 : 게시글 조회를 떠나면 뷰모델을 초기화함.
애초에 게시글을 읽은 후에, 해당 글에 정보를 담고 있을 필요가 없다.